### PR TITLE
Add option to not manage the Sphinx service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,8 +1,10 @@
 class sphinx (
-  $package_name   = $sphinx::params::sphinx_package_name,
-  $package_ensure = 'present',
-  $service_name   = $sphinx::params::sphinx_service_name,
-  $config_file    = undef,
+  $package_name            = $sphinx::params::sphinx_package_name,
+  $package_ensure          = 'present',
+  $service_name            = $sphinx::params::sphinx_service_name,
+  $service_enable          = true,
+  $sphinx_activate_service = $sphinx::params::sphinx_activate_service,
+  $config_file             = undef,
 ) inherits sphinx::params {
 
   anchor {'sphinx_first':} -> Class['sphinx::package']
@@ -10,20 +12,30 @@ class sphinx (
   class { 'sphinx::package':
     package_name   => $package_name,
     package_ensure => $package_ensure,
-    notify         => Class['sphinx::service'],
+    notify         => $service_enable ? {
+      true    => Class['sphinx::service'],
+      default => undef,
+    },
   }
 
   class { 'sphinx::config':
-    activate_service   => $sphinx::params::sphinx_activate_service,
+    activate_service   => $sphinx_activate_service,
     config_file_source => $config_file,
     config_file_path   => $sphinx::params::sphinx_config_file_path,
     require            => Class['sphinx::package'],
-    notify             => Class['sphinx::service'],
+    notify             => $service_enable ? {
+      true    => Class['sphinx::service'],
+      default => undef,
+    },
   }
 
-  class { 'sphinx::service':
-    service_name => $service_name,
+  if $service_enable {
+    class { 'sphinx::service':
+      service_name => $service_name,
+    }
+    Class['sphinx::service'] -> anchor {'sphinx_last':}
+  } else {
+    Class['sphinx::config'] -> anchor {'sphinx_last':}
   }
 
-  Class['sphinx::service'] -> anchor {'sphinx_last':}
 }


### PR DESCRIPTION
Previously, the Sphinx service was being managed regardless of how the main
sphinx class was declared. This commit adds the ability to pass a $service_enable
parameter, as well as exposes the $sphinx_activate_service parameter to the main
sphinx class (that way you can pass in the parameter without having to directly
modify the variable in the params class, thus making the class more modular).
By exposing these parameters, it enables the ability to disable managing the
Sphinx service (should it be controlled by other means).
